### PR TITLE
Add ad action delay option

### DIFF
--- a/NHLGames/English.resx
+++ b/NHLGames/English.resx
@@ -977,11 +977,11 @@
     <value>Recap</value>
     <comment>Game panel</comment>
   </data>
-  <data name="lblAdActionDelay" xml:space="preserve">
-    <value>Activation delay</value>
+  <data name="lblMediaControlDelay" xml:space="preserve">
+    <value>Media control delay</value>
     <comment>Settings Tab</comment>
   </data>
-  <data name="tipAdActionDelay" xml:space="preserve">
+  <data name="tipMediaControlDelay" xml:space="preserve">
     <value>Raising this value may fix music still playing after a commercial break.</value>
     <comment>Settings Tab</comment>
   </data>

--- a/NHLGames/English.resx
+++ b/NHLGames/English.resx
@@ -977,4 +977,12 @@
     <value>Recap</value>
     <comment>Game panel</comment>
   </data>
+  <data name="lblAdActionDelay" xml:space="preserve">
+    <value>Activation delay</value>
+    <comment>Settings Tab</comment>
+  </data>
+  <data name="tipAdActionDelay" xml:space="preserve">
+    <value>Raising this value may fix music still playing after a commercial break.</value>
+    <comment>Settings Tab</comment>
+  </data>
 </root>

--- a/NHLGames/English1.Designer.vb
+++ b/NHLGames/English1.Designer.vb
@@ -686,15 +686,6 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Activation delay.
-        '''</summary>
-        Friend Shared ReadOnly Property lblAdActionDelay() As String
-            Get
-                Return ResourceManager.GetString("lblAdActionDelay", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Use the alternate network.
         '''</summary>
         Friend Shared ReadOnly Property lblAlternateCdn() As String
@@ -844,6 +835,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property lblLiveRewindDetails() As String
             Get
                 Return ResourceManager.GetString("lblLiveRewindDetails", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Media control delay.
+        '''</summary>
+        Friend Shared ReadOnly Property lblMediaControlDelay() As String
+            Get
+                Return ResourceManager.GetString("lblMediaControlDelay", resourceCulture)
             End Get
         End Property
         
@@ -1748,15 +1748,6 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Raising this value may fix music still playing after a commercial break..
-        '''</summary>
-        Friend Shared ReadOnly Property tipAdActionDelay() As String
-            Get
-                Return ResourceManager.GetString("tipAdActionDelay", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Broken stream.
         '''</summary>
         Friend Shared ReadOnly Property tipBrokenStream() As String
@@ -1861,6 +1852,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property tipLiveStatusRewind() As String
             Get
                 Return ResourceManager.GetString("tipLiveStatusRewind", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Raising this value may fix music still playing after a commercial break..
+        '''</summary>
+        Friend Shared ReadOnly Property tipMediaControlDelay() As String
+            Get
+                Return ResourceManager.GetString("tipMediaControlDelay", resourceCulture)
             End Get
         End Property
         

--- a/NHLGames/English1.Designer.vb
+++ b/NHLGames/English1.Designer.vb
@@ -22,7 +22,7 @@ Namespace My.Resources
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute()>  _
     Friend Class English
@@ -682,6 +682,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property gameSeriesWin() As String
             Get
                 Return ResourceManager.GetString("gameSeriesWin", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Activation delay.
+        '''</summary>
+        Friend Shared ReadOnly Property lblAdActionDelay() As String
+            Get
+                Return ResourceManager.GetString("lblAdActionDelay", resourceCulture)
             End Get
         End Property
         
@@ -1735,6 +1744,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property tabSettings() As String
             Get
                 Return ResourceManager.GetString("tabSettings", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Raising this value may fix music still playing after a commercial break..
+        '''</summary>
+        Friend Shared ReadOnly Property tipAdActionDelay() As String
+            Get
+                Return ResourceManager.GetString("tipAdActionDelay", resourceCulture)
             End Get
         End Property
         

--- a/NHLGames/French.Designer.vb
+++ b/NHLGames/French.Designer.vb
@@ -22,7 +22,7 @@ Namespace My.Resources
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute()>  _
     Friend Class French
@@ -502,6 +502,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property gameSeriesWin() As String
             Get
                 Return ResourceManager.GetString("gameSeriesWin", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Délai d&apos;activation.
+        '''</summary>
+        Friend Shared ReadOnly Property lblAdActionDelay() As String
+            Get
+                Return ResourceManager.GetString("lblAdActionDelay", resourceCulture)
             End Get
         End Property
         
@@ -1249,6 +1258,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property tabSettings() As String
             Get
                 Return ResourceManager.GetString("tabSettings", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Augmenter cette valeur peut corriger la musique qui continue après une pause commerciale..
+        '''</summary>
+        Friend Shared ReadOnly Property tipAdActionDelay() As String
+            Get
+                Return ResourceManager.GetString("tipAdActionDelay", resourceCulture)
             End Get
         End Property
         

--- a/NHLGames/French.Designer.vb
+++ b/NHLGames/French.Designer.vb
@@ -506,15 +506,6 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Délai d&apos;activation.
-        '''</summary>
-        Friend Shared ReadOnly Property lblAdActionDelay() As String
-            Get
-                Return ResourceManager.GetString("lblAdActionDelay", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Utiliser le réseau alternatif.
         '''</summary>
         Friend Shared ReadOnly Property lblAlternateCdn() As String
@@ -664,6 +655,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property lblLiveRewindDetails() As String
             Get
                 Return ResourceManager.GetString("lblLiveRewindDetails", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Délai des contrôles de médias.
+        '''</summary>
+        Friend Shared ReadOnly Property lblMediaControlDelay() As String
+            Get
+                Return ResourceManager.GetString("lblMediaControlDelay", resourceCulture)
             End Get
         End Property
         
@@ -1262,15 +1262,6 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Augmenter cette valeur peut corriger la musique qui continue après une pause commerciale..
-        '''</summary>
-        Friend Shared ReadOnly Property tipAdActionDelay() As String
-            Get
-                Return ResourceManager.GetString("tipAdActionDelay", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Stream brisé.
         '''</summary>
         Friend Shared ReadOnly Property tipBrokenStream() As String
@@ -1375,6 +1366,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property tipLiveStatusRewind() As String
             Get
                 Return ResourceManager.GetString("tipLiveStatusRewind", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Augmenter cette valeur peut corriger les médias qui continue après une pause commerciale..
+        '''</summary>
+        Friend Shared ReadOnly Property tipMediaControlDelay() As String
+            Get
+                Return ResourceManager.GetString("tipMediaControlDelay", resourceCulture)
             End Get
         End Property
         

--- a/NHLGames/French.resx
+++ b/NHLGames/French.resx
@@ -761,4 +761,12 @@
     <value>Résumé</value>
     <comment>Game panel</comment>
   </data>
+  <data name="lblAdActionDelay" xml:space="preserve">
+    <value>Délai d'activation</value>
+    <comment>Settings Tab</comment>
+  </data>
+  <data name="tipAdActionDelay" xml:space="preserve">
+    <value>Augmenter cette valeur peut corriger la musique qui continue après une pause commerciale.</value>
+    <comment>Settings Tab</comment>
+  </data>
 </root>

--- a/NHLGames/French.resx
+++ b/NHLGames/French.resx
@@ -761,12 +761,12 @@
     <value>Résumé</value>
     <comment>Game panel</comment>
   </data>
-  <data name="lblAdActionDelay" xml:space="preserve">
-    <value>Délai d'activation</value>
+  <data name="lblMediaControlDelay" xml:space="preserve">
+    <value>Délai des contrôles de médias</value>
     <comment>Settings Tab</comment>
   </data>
-  <data name="tipAdActionDelay" xml:space="preserve">
-    <value>Augmenter cette valeur peut corriger la musique qui continue après une pause commerciale.</value>
+  <data name="tipMediaControlDelay" xml:space="preserve">
+    <value>Augmenter cette valeur peut corriger les médias qui continue après une pause commerciale.</value>
     <comment>Settings Tab</comment>
   </data>
 </root>

--- a/NHLGames/NHLGamesMetro.Designer.vb
+++ b/NHLGames/NHLGamesMetro.Designer.vb
@@ -72,9 +72,9 @@ Partial Class NHLGamesMetro
         Me.flpSpotifyDescSettings = New System.Windows.Forms.FlowLayoutPanel()
         Me.tgSpotify = New MetroFramework.Controls.MetroToggle()
         Me.lblSpotifyDesc = New MetroFramework.Controls.MetroLabel()
-        Me.lblAdActionDelay = New MetroFramework.Controls.MetroLabel()
-        Me.txtAdActionDelay = New MetroFramework.Controls.MetroTextBox()
-        Me.lblAdActionDelayMs = New MetroFramework.Controls.MetroLabel()
+        Me.lblMediaControlDelay = New MetroFramework.Controls.MetroLabel()
+        Me.txtMediaControlDelay = New MetroFramework.Controls.MetroTextBox()
+        Me.lblMediaControlDelayMs = New MetroFramework.Controls.MetroLabel()
         Me.cbStreamQuality = New NHLGames.Controls.MetroComboBoxNoMW()
         Me.lblStreamerArgs = New MetroFramework.Controls.MetroLabel()
         Me.lblPlayerArgs = New MetroFramework.Controls.MetroLabel()
@@ -161,7 +161,6 @@ Partial Class NHLGamesMetro
         Me.cbLiveReplay = New NHLGames.Controls.MetroComboBoxNoMW()
         Me.tgDarkMode = New MetroFramework.Controls.MetroToggle()
         Me.lblDarkMode = New MetroFramework.Controls.MetroLabel()
-        Me.flpAdActionDelay = New System.Windows.Forms.FlowLayoutPanel()
         Me.tabConsole = New MetroFramework.Controls.MetroTabPage()
         Me.btnCopyConsole = New MetroFramework.Controls.MetroButton()
         Me.btnClearConsole = New MetroFramework.Controls.MetroButton()
@@ -471,8 +470,8 @@ Partial Class NHLGamesMetro
         Me.tlpSettings.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle())
         Me.tlpSettings.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
         Me.tlpSettings.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpSettings.Controls.Add(Me.tlpOBSSettings, 2, 29)
-        Me.tlpSettings.Controls.Add(Me.flpObsDescSettings, 2, 28)
+        Me.tlpSettings.Controls.Add(Me.tlpOBSSettings, 2, 28)
+        Me.tlpSettings.Controls.Add(Me.flpObsDescSettings, 2, 27)
         Me.tlpSettings.Controls.Add(Me.flpSpotifyDescSettings, 2, 25)
         Me.tlpSettings.Controls.Add(Me.cbStreamQuality, 2, 3)
         Me.tlpSettings.Controls.Add(Me.lblStreamerArgs, 0, 22)
@@ -502,7 +501,7 @@ Partial Class NHLGamesMetro
         Me.tlpSettings.Controls.Add(Me.flpSelectedPlayer, 2, 11)
         Me.tlpSettings.Controls.Add(Me.tlpCdnSettings, 2, 7)
         Me.tlpSettings.Controls.Add(Me.lblSpotify, 0, 25)
-        Me.tlpSettings.Controls.Add(Me.lblOBS, 0, 28)
+        Me.tlpSettings.Controls.Add(Me.lblOBS, 0, 27)
         Me.tlpSettings.Controls.Add(Me.flpSpotifyParameters, 2, 26)
         Me.tlpSettings.Controls.Add(Me.lblModules, 0, 24)
         Me.tlpSettings.Controls.Add(Me.flpAdDetection, 2, 24)
@@ -513,14 +512,13 @@ Partial Class NHLGamesMetro
         Me.tlpSettings.Controls.Add(Me.cbLiveReplay, 2, 4)
         Me.tlpSettings.Controls.Add(Me.tgDarkMode, 2, 17)
         Me.tlpSettings.Controls.Add(Me.lblDarkMode, 0, 17)
-        Me.tlpSettings.Controls.Add(Me.flpAdActionDelay, 2, 27)
         Me.tlpSettings.ForeColor = System.Drawing.SystemColors.ControlText
         Me.tlpSettings.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize
         Me.tlpSettings.Location = New System.Drawing.Point(1, 1)
         Me.tlpSettings.Margin = New System.Windows.Forms.Padding(0)
         Me.tlpSettings.Name = "tlpSettings"
         Me.tlpSettings.Padding = New System.Windows.Forms.Padding(0, 0, 20, 0)
-        Me.tlpSettings.RowCount = 31
+        Me.tlpSettings.RowCount = 30
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle())
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
@@ -549,7 +547,6 @@ Partial Class NHLGamesMetro
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
-        Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 100.0!))
         Me.tlpSettings.Size = New System.Drawing.Size(982, 514)
@@ -567,7 +564,7 @@ Partial Class NHLGamesMetro
         Me.tlpOBSSettings.Controls.Add(Me.flpAdSceneHotkey, 1, 1)
         Me.tlpOBSSettings.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tlpOBSSettings.Enabled = False
-        Me.tlpOBSSettings.Location = New System.Drawing.Point(174, 990)
+        Me.tlpOBSSettings.Location = New System.Drawing.Point(174, 960)
         Me.tlpOBSSettings.Margin = New System.Windows.Forms.Padding(0)
         Me.tlpOBSSettings.Name = "tlpOBSSettings"
         Me.tlpOBSSettings.RowCount = 2
@@ -826,7 +823,7 @@ Partial Class NHLGamesMetro
         Me.flpObsDescSettings.Controls.Add(Me.tgOBS)
         Me.flpObsDescSettings.Controls.Add(Me.lblOBSDesc)
         Me.flpObsDescSettings.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.flpObsDescSettings.Location = New System.Drawing.Point(174, 960)
+        Me.flpObsDescSettings.Location = New System.Drawing.Point(174, 930)
         Me.flpObsDescSettings.Margin = New System.Windows.Forms.Padding(0)
         Me.flpObsDescSettings.Name = "flpObsDescSettings"
         Me.flpObsDescSettings.Size = New System.Drawing.Size(771, 30)
@@ -859,9 +856,9 @@ Partial Class NHLGamesMetro
         '
         Me.flpSpotifyDescSettings.Controls.Add(Me.tgSpotify)
         Me.flpSpotifyDescSettings.Controls.Add(Me.lblSpotifyDesc)
-        Me.flpSpotifyDescSettings.Controls.Add(Me.lblAdActionDelay)
-        Me.flpSpotifyDescSettings.Controls.Add(Me.txtAdActionDelay)
-        Me.flpSpotifyDescSettings.Controls.Add(Me.lblAdActionDelayMs)
+        Me.flpSpotifyDescSettings.Controls.Add(Me.lblMediaControlDelay)
+        Me.flpSpotifyDescSettings.Controls.Add(Me.txtMediaControlDelay)
+        Me.flpSpotifyDescSettings.Controls.Add(Me.lblMediaControlDelayMs)
         Me.flpSpotifyDescSettings.Dock = System.Windows.Forms.DockStyle.Fill
         Me.flpSpotifyDescSettings.Location = New System.Drawing.Point(174, 870)
         Me.flpSpotifyDescSettings.Margin = New System.Windows.Forms.Padding(0)
@@ -892,57 +889,57 @@ Partial Class NHLGamesMetro
         Me.lblSpotifyDesc.Text = "SPOTIFY_DESC"
         Me.lblSpotifyDesc.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
         '
-        'lblAdActionDelay
+        'lblMediaControlDelay
         '
-        Me.lblAdActionDelay.AutoSize = True
-        Me.lblAdActionDelay.Dock = System.Windows.Forms.DockStyle.Right
-        Me.lblAdActionDelay.Location = New System.Drawing.Point(227, 3)
-        Me.lblAdActionDelay.Margin = New System.Windows.Forms.Padding(50, 3, 3, 3)
-        Me.lblAdActionDelay.Name = "lblAdActionDelay"
-        Me.lblAdActionDelay.Size = New System.Drawing.Size(126, 23)
-        Me.lblAdActionDelay.TabIndex = 530
-        Me.lblAdActionDelay.Text = "AD_ACTION_DELAY"
+        Me.lblMediaControlDelay.AutoSize = True
+        Me.lblMediaControlDelay.Dock = System.Windows.Forms.DockStyle.Right
+        Me.lblMediaControlDelay.Location = New System.Drawing.Point(227, 3)
+        Me.lblMediaControlDelay.Margin = New System.Windows.Forms.Padding(50, 3, 3, 3)
+        Me.lblMediaControlDelay.Name = "lblMediaControlDelay"
+        Me.lblMediaControlDelay.Size = New System.Drawing.Size(161, 23)
+        Me.lblMediaControlDelay.TabIndex = 530
+        Me.lblMediaControlDelay.Text = "MEDIA_CONTROL_DELAY"
         '
-        'txtAdActionDelay
-        '
-        '
+        'txtMediaControlDelay
         '
         '
-        Me.txtAdActionDelay.CustomButton.Image = Nothing
-        Me.txtAdActionDelay.CustomButton.Location = New System.Drawing.Point(22, 1)
-        Me.txtAdActionDelay.CustomButton.Name = ""
-        Me.txtAdActionDelay.CustomButton.Size = New System.Drawing.Size(21, 21)
-        Me.txtAdActionDelay.CustomButton.Style = MetroFramework.MetroColorStyle.Blue
-        Me.txtAdActionDelay.CustomButton.TabIndex = 1
-        Me.txtAdActionDelay.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light
-        Me.txtAdActionDelay.CustomButton.UseSelectable = True
-        Me.txtAdActionDelay.CustomButton.Visible = False
-        Me.txtAdActionDelay.Lines = New String(-1) {}
-        Me.txtAdActionDelay.Location = New System.Drawing.Point(359, 3)
-        Me.txtAdActionDelay.MaxLength = 5
-        Me.txtAdActionDelay.Name = "txtAdActionDelay"
-        Me.txtAdActionDelay.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
-        Me.txtAdActionDelay.ScrollBars = System.Windows.Forms.ScrollBars.None
-        Me.txtAdActionDelay.SelectedText = ""
-        Me.txtAdActionDelay.SelectionLength = 0
-        Me.txtAdActionDelay.SelectionStart = 0
-        Me.txtAdActionDelay.ShortcutsEnabled = True
-        Me.txtAdActionDelay.Size = New System.Drawing.Size(44, 23)
-        Me.txtAdActionDelay.TabIndex = 528
-        Me.txtAdActionDelay.UseSelectable = True
-        Me.txtAdActionDelay.WaterMarkColor = System.Drawing.Color.FromArgb(CType(CType(109, Byte), Integer), CType(CType(109, Byte), Integer), CType(CType(109, Byte), Integer))
-        Me.txtAdActionDelay.WaterMarkFont = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel)
         '
-        'lblAdActionDelayMs
         '
-        Me.lblAdActionDelayMs.AutoSize = True
-        Me.lblAdActionDelayMs.Location = New System.Drawing.Point(409, 3)
-        Me.lblAdActionDelayMs.Margin = New System.Windows.Forms.Padding(3)
-        Me.lblAdActionDelayMs.Name = "lblAdActionDelayMs"
-        Me.lblAdActionDelayMs.Size = New System.Drawing.Size(26, 19)
-        Me.lblAdActionDelayMs.TabIndex = 529
-        Me.lblAdActionDelayMs.Text = "ms"
-        Me.lblAdActionDelayMs.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
+        Me.txtMediaControlDelay.CustomButton.Image = Nothing
+        Me.txtMediaControlDelay.CustomButton.Location = New System.Drawing.Point(22, 1)
+        Me.txtMediaControlDelay.CustomButton.Name = ""
+        Me.txtMediaControlDelay.CustomButton.Size = New System.Drawing.Size(21, 21)
+        Me.txtMediaControlDelay.CustomButton.Style = MetroFramework.MetroColorStyle.Blue
+        Me.txtMediaControlDelay.CustomButton.TabIndex = 1
+        Me.txtMediaControlDelay.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light
+        Me.txtMediaControlDelay.CustomButton.UseSelectable = True
+        Me.txtMediaControlDelay.CustomButton.Visible = False
+        Me.txtMediaControlDelay.Lines = New String(-1) {}
+        Me.txtMediaControlDelay.Location = New System.Drawing.Point(394, 3)
+        Me.txtMediaControlDelay.MaxLength = 5
+        Me.txtMediaControlDelay.Name = "txtMediaControlDelay"
+        Me.txtMediaControlDelay.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
+        Me.txtMediaControlDelay.ScrollBars = System.Windows.Forms.ScrollBars.None
+        Me.txtMediaControlDelay.SelectedText = ""
+        Me.txtMediaControlDelay.SelectionLength = 0
+        Me.txtMediaControlDelay.SelectionStart = 0
+        Me.txtMediaControlDelay.ShortcutsEnabled = True
+        Me.txtMediaControlDelay.Size = New System.Drawing.Size(44, 23)
+        Me.txtMediaControlDelay.TabIndex = 528
+        Me.txtMediaControlDelay.UseSelectable = True
+        Me.txtMediaControlDelay.WaterMarkColor = System.Drawing.Color.FromArgb(CType(CType(109, Byte), Integer), CType(CType(109, Byte), Integer), CType(CType(109, Byte), Integer))
+        Me.txtMediaControlDelay.WaterMarkFont = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel)
+        '
+        'lblMediaControlDelayMs
+        '
+        Me.lblMediaControlDelayMs.AutoSize = True
+        Me.lblMediaControlDelayMs.Location = New System.Drawing.Point(444, 3)
+        Me.lblMediaControlDelayMs.Margin = New System.Windows.Forms.Padding(3)
+        Me.lblMediaControlDelayMs.Name = "lblMediaControlDelayMs"
+        Me.lblMediaControlDelayMs.Size = New System.Drawing.Size(26, 19)
+        Me.lblMediaControlDelayMs.TabIndex = 529
+        Me.lblMediaControlDelayMs.Text = "ms"
+        Me.lblMediaControlDelayMs.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
         '
         'cbStreamQuality
         '
@@ -1755,7 +1752,7 @@ Partial Class NHLGamesMetro
         '
         Me.lblOBS.AutoSize = True
         Me.lblOBS.Dock = System.Windows.Forms.DockStyle.Right
-        Me.lblOBS.Location = New System.Drawing.Point(3, 963)
+        Me.lblOBS.Location = New System.Drawing.Point(3, 933)
         Me.lblOBS.Margin = New System.Windows.Forms.Padding(3)
         Me.lblOBS.Name = "lblOBS"
         Me.lblOBS.Size = New System.Drawing.Size(148, 24)
@@ -1961,16 +1958,6 @@ Partial Class NHLGamesMetro
         Me.lblDarkMode.TabIndex = 524
         Me.lblDarkMode.Text = "DARK"
         Me.lblDarkMode.TextAlign = System.Drawing.ContentAlignment.MiddleRight
-        '
-        'flpAdActionDelay
-        '
-        Me.flpAdActionDelay.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.flpAdActionDelay.Enabled = False
-        Me.flpAdActionDelay.Location = New System.Drawing.Point(174, 930)
-        Me.flpAdActionDelay.Margin = New System.Windows.Forms.Padding(0)
-        Me.flpAdActionDelay.Name = "flpAdActionDelay"
-        Me.flpAdActionDelay.Size = New System.Drawing.Size(771, 30)
-        Me.flpAdActionDelay.TabIndex = 526
         '
         'tabConsole
         '
@@ -2206,17 +2193,17 @@ Partial Class NHLGamesMetro
         Me.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.AutoValidate = System.Windows.Forms.AutoValidate.Disable
         Me.BackMaxSize = 150
-        Me.CausesValidation = false
+        Me.CausesValidation = False
         Me.ClientSize = New System.Drawing.Size(990, 655)
         Me.Controls.Add(Me.pnlLogo)
         Me.Controls.Add(Me.spnStreaming)
         Me.Controls.Add(Me.pnlBottom)
         Me.Controls.Add(Me.btnHelp)
         Me.Controls.Add(Me.tabMenu)
-        Me.Font = New System.Drawing.Font("Segoe UI", 9!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0,Byte))
+        Me.Font = New System.Drawing.Font("Segoe UI", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.ForeColor = System.Drawing.SystemColors.ControlText
-        Me.HelpButton = true
-        Me.Icon = CType(resources.GetObject("$this.Icon"),System.Drawing.Icon)
+        Me.HelpButton = True
+        Me.Icon = CType(resources.GetObject("$this.Icon"), System.Drawing.Icon)
         Me.ImeMode = System.Windows.Forms.ImeMode.Close
         Me.MinimumSize = New System.Drawing.Size(990, 500)
         Me.Name = "NHLGamesMetro"
@@ -2224,59 +2211,59 @@ Partial Class NHLGamesMetro
         Me.ShadowType = MetroFramework.Forms.MetroFormShadowType.SystemShadow
         Me.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide
         Me.Text = "NHLGames"
-        Me.tabMenu.ResumeLayout(false)
-        Me.tabGames.ResumeLayout(false)
-        Me.tabGames.PerformLayout
-        Me.pnlGameBar.ResumeLayout(false)
-        Me.tabSettings.ResumeLayout(false)
-        Me.tlpSettings.ResumeLayout(false)
-        Me.tlpSettings.PerformLayout
-        Me.tlpOBSSettings.ResumeLayout(false)
-        Me.tlpOBSSettings.PerformLayout
-        Me.flpGameSceneHotkey.ResumeLayout(false)
-        Me.flpGameSceneHotkey.PerformLayout
-        Me.flpAdSceneHotkey.ResumeLayout(false)
-        Me.flpAdSceneHotkey.PerformLayout
-        Me.flpObsDescSettings.ResumeLayout(false)
-        Me.flpObsDescSettings.PerformLayout
-        Me.flpSpotifyDescSettings.ResumeLayout(false)
-        Me.flpSpotifyDescSettings.PerformLayout
-        Me.flpStreamerArgs.ResumeLayout(false)
-        Me.flpStreamerArgs.PerformLayout
-        Me.flpPlayerArgs.ResumeLayout(false)
-        Me.flpPlayerArgs.PerformLayout
-        Me.flpOutputSettings.ResumeLayout(false)
-        Me.flpOutputSettings.PerformLayout
-        Me.flpStreamerPath.ResumeLayout(false)
-        Me.flpStreamerPath.PerformLayout
-        Me.flpMpvPath.ResumeLayout(false)
-        Me.flpMpvPath.PerformLayout
-        Me.flpMpcPath.ResumeLayout(false)
-        Me.flpMpcPath.PerformLayout
-        Me.flpVlcPath.ResumeLayout(false)
-        Me.flpVlcPath.PerformLayout
-        Me.flpLanguage.ResumeLayout(false)
-        Me.flpHostsFile.ResumeLayout(false)
-        Me.tlpGamePanelSettings.ResumeLayout(false)
-        Me.tlpGamePanelSettings.PerformLayout
-        Me.flpSelectedPlayer.ResumeLayout(false)
-        Me.tlpCdnSettings.ResumeLayout(false)
-        Me.tlpCdnSettings.PerformLayout
-        Me.flpSpotifyParameters.ResumeLayout(false)
-        Me.flpSpotifyParameters.PerformLayout
-        Me.flpAdDetection.ResumeLayout(false)
-        Me.flpAdDetection.PerformLayout
-        Me.tlpReplay.ResumeLayout(false)
-        Me.tlpReplay.PerformLayout
-        Me.tabConsole.ResumeLayout(false)
-        Me.pnlBottom.ResumeLayout(false)
-        Me.tlpStatus.ResumeLayout(false)
-        Me.tlpStatus.PerformLayout
-        Me.TableLayoutPanel1.ResumeLayout(false)
-        Me.TableLayoutPanel1.PerformLayout
-        Me.ResumeLayout(false)
+        Me.tabMenu.ResumeLayout(False)
+        Me.tabGames.ResumeLayout(False)
+        Me.tabGames.PerformLayout()
+        Me.pnlGameBar.ResumeLayout(False)
+        Me.tabSettings.ResumeLayout(False)
+        Me.tlpSettings.ResumeLayout(False)
+        Me.tlpSettings.PerformLayout()
+        Me.tlpOBSSettings.ResumeLayout(False)
+        Me.tlpOBSSettings.PerformLayout()
+        Me.flpGameSceneHotkey.ResumeLayout(False)
+        Me.flpGameSceneHotkey.PerformLayout()
+        Me.flpAdSceneHotkey.ResumeLayout(False)
+        Me.flpAdSceneHotkey.PerformLayout()
+        Me.flpObsDescSettings.ResumeLayout(False)
+        Me.flpObsDescSettings.PerformLayout()
+        Me.flpSpotifyDescSettings.ResumeLayout(False)
+        Me.flpSpotifyDescSettings.PerformLayout()
+        Me.flpStreamerArgs.ResumeLayout(False)
+        Me.flpStreamerArgs.PerformLayout()
+        Me.flpPlayerArgs.ResumeLayout(False)
+        Me.flpPlayerArgs.PerformLayout()
+        Me.flpOutputSettings.ResumeLayout(False)
+        Me.flpOutputSettings.PerformLayout()
+        Me.flpStreamerPath.ResumeLayout(False)
+        Me.flpStreamerPath.PerformLayout()
+        Me.flpMpvPath.ResumeLayout(False)
+        Me.flpMpvPath.PerformLayout()
+        Me.flpMpcPath.ResumeLayout(False)
+        Me.flpMpcPath.PerformLayout()
+        Me.flpVlcPath.ResumeLayout(False)
+        Me.flpVlcPath.PerformLayout()
+        Me.flpLanguage.ResumeLayout(False)
+        Me.flpHostsFile.ResumeLayout(False)
+        Me.tlpGamePanelSettings.ResumeLayout(False)
+        Me.tlpGamePanelSettings.PerformLayout()
+        Me.flpSelectedPlayer.ResumeLayout(False)
+        Me.tlpCdnSettings.ResumeLayout(False)
+        Me.tlpCdnSettings.PerformLayout()
+        Me.flpSpotifyParameters.ResumeLayout(False)
+        Me.flpSpotifyParameters.PerformLayout()
+        Me.flpAdDetection.ResumeLayout(False)
+        Me.flpAdDetection.PerformLayout()
+        Me.tlpReplay.ResumeLayout(False)
+        Me.tlpReplay.PerformLayout()
+        Me.tabConsole.ResumeLayout(False)
+        Me.pnlBottom.ResumeLayout(False)
+        Me.tlpStatus.ResumeLayout(False)
+        Me.tlpStatus.PerformLayout()
+        Me.TableLayoutPanel1.ResumeLayout(False)
+        Me.TableLayoutPanel1.PerformLayout()
+        Me.ResumeLayout(False)
 
-End Sub
+    End Sub
     Friend WithEvents txtConsole As RichTextBox
     Friend WithEvents tabMenu As MetroTabControl
     Friend WithEvents tabGames As MetroTabPage
@@ -2422,8 +2409,7 @@ End Sub
     Friend WithEvents lnkRelease As MetroLink
     Friend WithEvents lblTip As MetroLabel
     Friend WithEvents TableLayoutPanel1 As TableLayoutPanel
-    Friend WithEvents txtAdActionDelay As MetroTextBox
-    Friend WithEvents lblAdActionDelayMs As MetroLabel
-    Friend WithEvents flpAdActionDelay As FlowLayoutPanel
-    Friend WithEvents lblAdActionDelay As MetroLabel
+    Friend WithEvents txtMediaControlDelay As MetroTextBox
+    Friend WithEvents lblMediaControlDelayMs As MetroLabel
+    Friend WithEvents lblMediaControlDelay As MetroLabel
 End Class

--- a/NHLGames/NHLGamesMetro.Designer.vb
+++ b/NHLGames/NHLGamesMetro.Designer.vb
@@ -180,6 +180,7 @@ Partial Class NHLGamesMetro
         Me.bw = New System.ComponentModel.BackgroundWorker()
         Me.btnHelp = New MetroFramework.Controls.MetroLink()
         Me.pnlLogo = New System.Windows.Forms.Panel()
+        Me.FlowLayoutPanel1 = New System.Windows.Forms.FlowLayoutPanel()
         Me.tabMenu.SuspendLayout()
         Me.tabGames.SuspendLayout()
         Me.pnlGameBar.SuspendLayout()
@@ -209,6 +210,7 @@ Partial Class NHLGamesMetro
         Me.pnlBottom.SuspendLayout()
         Me.tlpStatus.SuspendLayout()
         Me.TableLayoutPanel1.SuspendLayout()
+        Me.FlowLayoutPanel1.SuspendLayout()
         Me.SuspendLayout()
         '
         'txtConsole
@@ -856,9 +858,6 @@ Partial Class NHLGamesMetro
         '
         Me.flpSpotifyDescSettings.Controls.Add(Me.tgSpotify)
         Me.flpSpotifyDescSettings.Controls.Add(Me.lblSpotifyDesc)
-        Me.flpSpotifyDescSettings.Controls.Add(Me.lblMediaControlDelay)
-        Me.flpSpotifyDescSettings.Controls.Add(Me.txtMediaControlDelay)
-        Me.flpSpotifyDescSettings.Controls.Add(Me.lblMediaControlDelayMs)
         Me.flpSpotifyDescSettings.Dock = System.Windows.Forms.DockStyle.Fill
         Me.flpSpotifyDescSettings.Location = New System.Drawing.Point(174, 870)
         Me.flpSpotifyDescSettings.Margin = New System.Windows.Forms.Padding(0)
@@ -892,13 +891,16 @@ Partial Class NHLGamesMetro
         'lblMediaControlDelay
         '
         Me.lblMediaControlDelay.AutoSize = True
-        Me.lblMediaControlDelay.Dock = System.Windows.Forms.DockStyle.Right
-        Me.lblMediaControlDelay.Location = New System.Drawing.Point(227, 3)
-        Me.lblMediaControlDelay.Margin = New System.Windows.Forms.Padding(50, 3, 3, 3)
+        Me.lblMediaControlDelay.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblMediaControlDelay.FontSize = MetroFramework.MetroLabelSize.Small
+        Me.lblMediaControlDelay.FontWeight = MetroFramework.MetroLabelWeight.Regular
+        Me.lblMediaControlDelay.Location = New System.Drawing.Point(3, 3)
+        Me.lblMediaControlDelay.Margin = New System.Windows.Forms.Padding(3)
         Me.lblMediaControlDelay.Name = "lblMediaControlDelay"
-        Me.lblMediaControlDelay.Size = New System.Drawing.Size(161, 23)
+        Me.lblMediaControlDelay.Size = New System.Drawing.Size(141, 23)
         Me.lblMediaControlDelay.TabIndex = 530
         Me.lblMediaControlDelay.Text = "MEDIA_CONTROL_DELAY"
+        Me.lblMediaControlDelay.TextAlign = System.Drawing.ContentAlignment.MiddleRight
         '
         'txtMediaControlDelay
         '
@@ -915,7 +917,7 @@ Partial Class NHLGamesMetro
         Me.txtMediaControlDelay.CustomButton.UseSelectable = True
         Me.txtMediaControlDelay.CustomButton.Visible = False
         Me.txtMediaControlDelay.Lines = New String(-1) {}
-        Me.txtMediaControlDelay.Location = New System.Drawing.Point(394, 3)
+        Me.txtMediaControlDelay.Location = New System.Drawing.Point(150, 3)
         Me.txtMediaControlDelay.MaxLength = 5
         Me.txtMediaControlDelay.Name = "txtMediaControlDelay"
         Me.txtMediaControlDelay.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
@@ -933,10 +935,12 @@ Partial Class NHLGamesMetro
         'lblMediaControlDelayMs
         '
         Me.lblMediaControlDelayMs.AutoSize = True
-        Me.lblMediaControlDelayMs.Location = New System.Drawing.Point(444, 3)
+        Me.lblMediaControlDelayMs.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.lblMediaControlDelayMs.FontSize = MetroFramework.MetroLabelSize.Small
+        Me.lblMediaControlDelayMs.Location = New System.Drawing.Point(200, 3)
         Me.lblMediaControlDelayMs.Margin = New System.Windows.Forms.Padding(3)
         Me.lblMediaControlDelayMs.Name = "lblMediaControlDelayMs"
-        Me.lblMediaControlDelayMs.Size = New System.Drawing.Size(26, 19)
+        Me.lblMediaControlDelayMs.Size = New System.Drawing.Size(22, 23)
         Me.lblMediaControlDelayMs.TabIndex = 529
         Me.lblMediaControlDelayMs.Text = "ms"
         Me.lblMediaControlDelayMs.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
@@ -1765,6 +1769,7 @@ Partial Class NHLGamesMetro
         Me.flpSpotifyParameters.Controls.Add(Me.chkSpotifyForceToStart)
         Me.flpSpotifyParameters.Controls.Add(Me.chkSpotifyPlayNextSong)
         Me.flpSpotifyParameters.Controls.Add(Me.chkSpotifyAnyMediaPlayer)
+        Me.flpSpotifyParameters.Controls.Add(Me.FlowLayoutPanel1)
         Me.flpSpotifyParameters.Dock = System.Windows.Forms.DockStyle.Fill
         Me.flpSpotifyParameters.Enabled = False
         Me.flpSpotifyParameters.Location = New System.Drawing.Point(174, 900)
@@ -2185,6 +2190,19 @@ Partial Class NHLGamesMetro
         Me.pnlLogo.Size = New System.Drawing.Size(170, 58)
         Me.pnlLogo.TabIndex = 10000
         '
+        'FlowLayoutPanel1
+        '
+        Me.FlowLayoutPanel1.AutoSize = True
+        Me.FlowLayoutPanel1.Controls.Add(Me.lblMediaControlDelay)
+        Me.FlowLayoutPanel1.Controls.Add(Me.txtMediaControlDelay)
+        Me.FlowLayoutPanel1.Controls.Add(Me.lblMediaControlDelayMs)
+        Me.FlowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.FlowLayoutPanel1.Location = New System.Drawing.Point(419, 0)
+        Me.FlowLayoutPanel1.Margin = New System.Windows.Forms.Padding(10, 0, 0, 0)
+        Me.FlowLayoutPanel1.Name = "FlowLayoutPanel1"
+        Me.FlowLayoutPanel1.Size = New System.Drawing.Size(225, 29)
+        Me.FlowLayoutPanel1.TabIndex = 531
+        '
         'NHLGamesMetro
         '
         Me.AccessibleDescription = "Watch NHL games for free in HD"
@@ -2261,6 +2279,8 @@ Partial Class NHLGamesMetro
         Me.tlpStatus.PerformLayout()
         Me.TableLayoutPanel1.ResumeLayout(False)
         Me.TableLayoutPanel1.PerformLayout()
+        Me.FlowLayoutPanel1.ResumeLayout(False)
+        Me.FlowLayoutPanel1.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -2412,4 +2432,5 @@ Partial Class NHLGamesMetro
     Friend WithEvents txtMediaControlDelay As MetroTextBox
     Friend WithEvents lblMediaControlDelayMs As MetroLabel
     Friend WithEvents lblMediaControlDelay As MetroLabel
+    Friend WithEvents FlowLayoutPanel1 As FlowLayoutPanel
 End Class

--- a/NHLGames/NHLGamesMetro.Designer.vb
+++ b/NHLGames/NHLGamesMetro.Designer.vb
@@ -72,6 +72,9 @@ Partial Class NHLGamesMetro
         Me.flpSpotifyDescSettings = New System.Windows.Forms.FlowLayoutPanel()
         Me.tgSpotify = New MetroFramework.Controls.MetroToggle()
         Me.lblSpotifyDesc = New MetroFramework.Controls.MetroLabel()
+        Me.lblAdActionDelay = New MetroFramework.Controls.MetroLabel()
+        Me.txtAdActionDelay = New MetroFramework.Controls.MetroTextBox()
+        Me.lblAdActionDelayMs = New MetroFramework.Controls.MetroLabel()
         Me.cbStreamQuality = New NHLGames.Controls.MetroComboBoxNoMW()
         Me.lblStreamerArgs = New MetroFramework.Controls.MetroLabel()
         Me.lblPlayerArgs = New MetroFramework.Controls.MetroLabel()
@@ -158,6 +161,7 @@ Partial Class NHLGamesMetro
         Me.cbLiveReplay = New NHLGames.Controls.MetroComboBoxNoMW()
         Me.tgDarkMode = New MetroFramework.Controls.MetroToggle()
         Me.lblDarkMode = New MetroFramework.Controls.MetroLabel()
+        Me.flpAdActionDelay = New System.Windows.Forms.FlowLayoutPanel()
         Me.tabConsole = New MetroFramework.Controls.MetroTabPage()
         Me.btnCopyConsole = New MetroFramework.Controls.MetroButton()
         Me.btnClearConsole = New MetroFramework.Controls.MetroButton()
@@ -467,8 +471,8 @@ Partial Class NHLGamesMetro
         Me.tlpSettings.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle())
         Me.tlpSettings.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20.0!))
         Me.tlpSettings.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.tlpSettings.Controls.Add(Me.tlpOBSSettings, 2, 28)
-        Me.tlpSettings.Controls.Add(Me.flpObsDescSettings, 2, 27)
+        Me.tlpSettings.Controls.Add(Me.tlpOBSSettings, 2, 29)
+        Me.tlpSettings.Controls.Add(Me.flpObsDescSettings, 2, 28)
         Me.tlpSettings.Controls.Add(Me.flpSpotifyDescSettings, 2, 25)
         Me.tlpSettings.Controls.Add(Me.cbStreamQuality, 2, 3)
         Me.tlpSettings.Controls.Add(Me.lblStreamerArgs, 0, 22)
@@ -498,7 +502,7 @@ Partial Class NHLGamesMetro
         Me.tlpSettings.Controls.Add(Me.flpSelectedPlayer, 2, 11)
         Me.tlpSettings.Controls.Add(Me.tlpCdnSettings, 2, 7)
         Me.tlpSettings.Controls.Add(Me.lblSpotify, 0, 25)
-        Me.tlpSettings.Controls.Add(Me.lblOBS, 0, 27)
+        Me.tlpSettings.Controls.Add(Me.lblOBS, 0, 28)
         Me.tlpSettings.Controls.Add(Me.flpSpotifyParameters, 2, 26)
         Me.tlpSettings.Controls.Add(Me.lblModules, 0, 24)
         Me.tlpSettings.Controls.Add(Me.flpAdDetection, 2, 24)
@@ -509,13 +513,14 @@ Partial Class NHLGamesMetro
         Me.tlpSettings.Controls.Add(Me.cbLiveReplay, 2, 4)
         Me.tlpSettings.Controls.Add(Me.tgDarkMode, 2, 17)
         Me.tlpSettings.Controls.Add(Me.lblDarkMode, 0, 17)
+        Me.tlpSettings.Controls.Add(Me.flpAdActionDelay, 2, 27)
         Me.tlpSettings.ForeColor = System.Drawing.SystemColors.ControlText
         Me.tlpSettings.GrowStyle = System.Windows.Forms.TableLayoutPanelGrowStyle.FixedSize
         Me.tlpSettings.Location = New System.Drawing.Point(1, 1)
         Me.tlpSettings.Margin = New System.Windows.Forms.Padding(0)
         Me.tlpSettings.Name = "tlpSettings"
         Me.tlpSettings.Padding = New System.Windows.Forms.Padding(0, 0, 20, 0)
-        Me.tlpSettings.RowCount = 30
+        Me.tlpSettings.RowCount = 31
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle())
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
@@ -544,6 +549,7 @@ Partial Class NHLGamesMetro
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
+        Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 60.0!))
         Me.tlpSettings.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 100.0!))
         Me.tlpSettings.Size = New System.Drawing.Size(982, 514)
@@ -561,7 +567,7 @@ Partial Class NHLGamesMetro
         Me.tlpOBSSettings.Controls.Add(Me.flpAdSceneHotkey, 1, 1)
         Me.tlpOBSSettings.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tlpOBSSettings.Enabled = False
-        Me.tlpOBSSettings.Location = New System.Drawing.Point(174, 960)
+        Me.tlpOBSSettings.Location = New System.Drawing.Point(174, 990)
         Me.tlpOBSSettings.Margin = New System.Windows.Forms.Padding(0)
         Me.tlpOBSSettings.Name = "tlpOBSSettings"
         Me.tlpOBSSettings.RowCount = 2
@@ -658,7 +664,7 @@ Partial Class NHLGamesMetro
         Me.chkGameCtrl.Location = New System.Drawing.Point(56, 6)
         Me.chkGameCtrl.Margin = New System.Windows.Forms.Padding(3, 6, 3, 3)
         Me.chkGameCtrl.Name = "chkGameCtrl"
-        Me.chkGameCtrl.Size = New System.Drawing.Size(51, 15)
+        Me.chkGameCtrl.Size = New System.Drawing.Size(50, 15)
         Me.chkGameCtrl.TabIndex = 4
         Me.chkGameCtrl.Text = "CTRL"
         Me.chkGameCtrl.UseSelectable = True
@@ -666,7 +672,7 @@ Partial Class NHLGamesMetro
         'lblPlus2
         '
         Me.lblPlus2.AutoSize = True
-        Me.lblPlus2.Location = New System.Drawing.Point(113, 3)
+        Me.lblPlus2.Location = New System.Drawing.Point(112, 3)
         Me.lblPlus2.Margin = New System.Windows.Forms.Padding(3)
         Me.lblPlus2.Name = "lblPlus2"
         Me.lblPlus2.Size = New System.Drawing.Size(18, 19)
@@ -676,10 +682,10 @@ Partial Class NHLGamesMetro
         'chkGameAlt
         '
         Me.chkGameAlt.AutoSize = True
-        Me.chkGameAlt.Location = New System.Drawing.Point(137, 6)
+        Me.chkGameAlt.Location = New System.Drawing.Point(136, 6)
         Me.chkGameAlt.Margin = New System.Windows.Forms.Padding(3, 6, 3, 3)
         Me.chkGameAlt.Name = "chkGameAlt"
-        Me.chkGameAlt.Size = New System.Drawing.Size(43, 15)
+        Me.chkGameAlt.Size = New System.Drawing.Size(42, 15)
         Me.chkGameAlt.TabIndex = 6
         Me.chkGameAlt.Text = "ALT"
         Me.chkGameAlt.UseSelectable = True
@@ -687,7 +693,7 @@ Partial Class NHLGamesMetro
         'lblPlus3
         '
         Me.lblPlus3.AutoSize = True
-        Me.lblPlus3.Location = New System.Drawing.Point(186, 3)
+        Me.lblPlus3.Location = New System.Drawing.Point(184, 3)
         Me.lblPlus3.Margin = New System.Windows.Forms.Padding(3)
         Me.lblPlus3.Name = "lblPlus3"
         Me.lblPlus3.Size = New System.Drawing.Size(18, 19)
@@ -697,10 +703,10 @@ Partial Class NHLGamesMetro
         'chkGameShift
         '
         Me.chkGameShift.AutoSize = True
-        Me.chkGameShift.Location = New System.Drawing.Point(210, 6)
+        Me.chkGameShift.Location = New System.Drawing.Point(208, 6)
         Me.chkGameShift.Margin = New System.Windows.Forms.Padding(3, 6, 3, 3)
         Me.chkGameShift.Name = "chkGameShift"
-        Me.chkGameShift.Size = New System.Drawing.Size(54, 15)
+        Me.chkGameShift.Size = New System.Drawing.Size(53, 15)
         Me.chkGameShift.TabIndex = 8
         Me.chkGameShift.Text = "SHIFT"
         Me.chkGameShift.UseSelectable = True
@@ -768,7 +774,7 @@ Partial Class NHLGamesMetro
         Me.chkAdCtrl.Location = New System.Drawing.Point(56, 6)
         Me.chkAdCtrl.Margin = New System.Windows.Forms.Padding(3, 6, 3, 3)
         Me.chkAdCtrl.Name = "chkAdCtrl"
-        Me.chkAdCtrl.Size = New System.Drawing.Size(51, 15)
+        Me.chkAdCtrl.Size = New System.Drawing.Size(50, 15)
         Me.chkAdCtrl.TabIndex = 5
         Me.chkAdCtrl.Text = "CTRL"
         Me.chkAdCtrl.UseSelectable = True
@@ -776,7 +782,7 @@ Partial Class NHLGamesMetro
         'lblPlus5
         '
         Me.lblPlus5.AutoSize = True
-        Me.lblPlus5.Location = New System.Drawing.Point(113, 3)
+        Me.lblPlus5.Location = New System.Drawing.Point(112, 3)
         Me.lblPlus5.Margin = New System.Windows.Forms.Padding(3)
         Me.lblPlus5.Name = "lblPlus5"
         Me.lblPlus5.Size = New System.Drawing.Size(18, 19)
@@ -786,10 +792,10 @@ Partial Class NHLGamesMetro
         'chkAdAlt
         '
         Me.chkAdAlt.AutoSize = True
-        Me.chkAdAlt.Location = New System.Drawing.Point(137, 6)
+        Me.chkAdAlt.Location = New System.Drawing.Point(136, 6)
         Me.chkAdAlt.Margin = New System.Windows.Forms.Padding(3, 6, 3, 3)
         Me.chkAdAlt.Name = "chkAdAlt"
-        Me.chkAdAlt.Size = New System.Drawing.Size(43, 15)
+        Me.chkAdAlt.Size = New System.Drawing.Size(42, 15)
         Me.chkAdAlt.TabIndex = 7
         Me.chkAdAlt.Text = "ALT"
         Me.chkAdAlt.UseSelectable = True
@@ -797,7 +803,7 @@ Partial Class NHLGamesMetro
         'lblPlus6
         '
         Me.lblPlus6.AutoSize = True
-        Me.lblPlus6.Location = New System.Drawing.Point(186, 3)
+        Me.lblPlus6.Location = New System.Drawing.Point(184, 3)
         Me.lblPlus6.Margin = New System.Windows.Forms.Padding(3)
         Me.lblPlus6.Name = "lblPlus6"
         Me.lblPlus6.Size = New System.Drawing.Size(18, 19)
@@ -807,10 +813,10 @@ Partial Class NHLGamesMetro
         'chkAdShift
         '
         Me.chkAdShift.AutoSize = True
-        Me.chkAdShift.Location = New System.Drawing.Point(210, 6)
+        Me.chkAdShift.Location = New System.Drawing.Point(208, 6)
         Me.chkAdShift.Margin = New System.Windows.Forms.Padding(3, 6, 3, 3)
         Me.chkAdShift.Name = "chkAdShift"
-        Me.chkAdShift.Size = New System.Drawing.Size(54, 15)
+        Me.chkAdShift.Size = New System.Drawing.Size(53, 15)
         Me.chkAdShift.TabIndex = 9
         Me.chkAdShift.Text = "SHIFT"
         Me.chkAdShift.UseSelectable = True
@@ -820,7 +826,7 @@ Partial Class NHLGamesMetro
         Me.flpObsDescSettings.Controls.Add(Me.tgOBS)
         Me.flpObsDescSettings.Controls.Add(Me.lblOBSDesc)
         Me.flpObsDescSettings.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.flpObsDescSettings.Location = New System.Drawing.Point(174, 930)
+        Me.flpObsDescSettings.Location = New System.Drawing.Point(174, 960)
         Me.flpObsDescSettings.Margin = New System.Windows.Forms.Padding(0)
         Me.flpObsDescSettings.Name = "flpObsDescSettings"
         Me.flpObsDescSettings.Size = New System.Drawing.Size(771, 30)
@@ -853,6 +859,9 @@ Partial Class NHLGamesMetro
         '
         Me.flpSpotifyDescSettings.Controls.Add(Me.tgSpotify)
         Me.flpSpotifyDescSettings.Controls.Add(Me.lblSpotifyDesc)
+        Me.flpSpotifyDescSettings.Controls.Add(Me.lblAdActionDelay)
+        Me.flpSpotifyDescSettings.Controls.Add(Me.txtAdActionDelay)
+        Me.flpSpotifyDescSettings.Controls.Add(Me.lblAdActionDelayMs)
         Me.flpSpotifyDescSettings.Dock = System.Windows.Forms.DockStyle.Fill
         Me.flpSpotifyDescSettings.Location = New System.Drawing.Point(174, 870)
         Me.flpSpotifyDescSettings.Margin = New System.Windows.Forms.Padding(0)
@@ -882,6 +891,58 @@ Partial Class NHLGamesMetro
         Me.lblSpotifyDesc.TabIndex = 75
         Me.lblSpotifyDesc.Text = "SPOTIFY_DESC"
         Me.lblSpotifyDesc.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
+        '
+        'lblAdActionDelay
+        '
+        Me.lblAdActionDelay.AutoSize = True
+        Me.lblAdActionDelay.Dock = System.Windows.Forms.DockStyle.Right
+        Me.lblAdActionDelay.Location = New System.Drawing.Point(227, 3)
+        Me.lblAdActionDelay.Margin = New System.Windows.Forms.Padding(50, 3, 3, 3)
+        Me.lblAdActionDelay.Name = "lblAdActionDelay"
+        Me.lblAdActionDelay.Size = New System.Drawing.Size(126, 23)
+        Me.lblAdActionDelay.TabIndex = 530
+        Me.lblAdActionDelay.Text = "AD_ACTION_DELAY"
+        '
+        'txtAdActionDelay
+        '
+        '
+        '
+        '
+        Me.txtAdActionDelay.CustomButton.Image = Nothing
+        Me.txtAdActionDelay.CustomButton.Location = New System.Drawing.Point(22, 1)
+        Me.txtAdActionDelay.CustomButton.Name = ""
+        Me.txtAdActionDelay.CustomButton.Size = New System.Drawing.Size(21, 21)
+        Me.txtAdActionDelay.CustomButton.Style = MetroFramework.MetroColorStyle.Blue
+        Me.txtAdActionDelay.CustomButton.TabIndex = 1
+        Me.txtAdActionDelay.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light
+        Me.txtAdActionDelay.CustomButton.UseSelectable = True
+        Me.txtAdActionDelay.CustomButton.Visible = False
+        Me.txtAdActionDelay.Lines = New String(-1) {}
+        Me.txtAdActionDelay.Location = New System.Drawing.Point(359, 3)
+        Me.txtAdActionDelay.MaxLength = 5
+        Me.txtAdActionDelay.Name = "txtAdActionDelay"
+        Me.txtAdActionDelay.PasswordChar = Global.Microsoft.VisualBasic.ChrW(0)
+        Me.txtAdActionDelay.ScrollBars = System.Windows.Forms.ScrollBars.None
+        Me.txtAdActionDelay.SelectedText = ""
+        Me.txtAdActionDelay.SelectionLength = 0
+        Me.txtAdActionDelay.SelectionStart = 0
+        Me.txtAdActionDelay.ShortcutsEnabled = True
+        Me.txtAdActionDelay.Size = New System.Drawing.Size(44, 23)
+        Me.txtAdActionDelay.TabIndex = 528
+        Me.txtAdActionDelay.UseSelectable = True
+        Me.txtAdActionDelay.WaterMarkColor = System.Drawing.Color.FromArgb(CType(CType(109, Byte), Integer), CType(CType(109, Byte), Integer), CType(CType(109, Byte), Integer))
+        Me.txtAdActionDelay.WaterMarkFont = New System.Drawing.Font("Segoe UI", 12.0!, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel)
+        '
+        'lblAdActionDelayMs
+        '
+        Me.lblAdActionDelayMs.AutoSize = True
+        Me.lblAdActionDelayMs.Location = New System.Drawing.Point(409, 3)
+        Me.lblAdActionDelayMs.Margin = New System.Windows.Forms.Padding(3)
+        Me.lblAdActionDelayMs.Name = "lblAdActionDelayMs"
+        Me.lblAdActionDelayMs.Size = New System.Drawing.Size(26, 19)
+        Me.lblAdActionDelayMs.TabIndex = 529
+        Me.lblAdActionDelayMs.Text = "ms"
+        Me.lblAdActionDelayMs.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
         '
         'cbStreamQuality
         '
@@ -1694,7 +1755,7 @@ Partial Class NHLGamesMetro
         '
         Me.lblOBS.AutoSize = True
         Me.lblOBS.Dock = System.Windows.Forms.DockStyle.Right
-        Me.lblOBS.Location = New System.Drawing.Point(3, 933)
+        Me.lblOBS.Location = New System.Drawing.Point(3, 963)
         Me.lblOBS.Margin = New System.Windows.Forms.Padding(3)
         Me.lblOBS.Name = "lblOBS"
         Me.lblOBS.Size = New System.Drawing.Size(148, 24)
@@ -1721,7 +1782,7 @@ Partial Class NHLGamesMetro
         Me.chkSpotifyForceToStart.Location = New System.Drawing.Point(12, 6)
         Me.chkSpotifyForceToStart.Margin = New System.Windows.Forms.Padding(12, 6, 6, 6)
         Me.chkSpotifyForceToStart.Name = "chkSpotifyForceToStart"
-        Me.chkSpotifyForceToStart.Size = New System.Drawing.Size(117, 15)
+        Me.chkSpotifyForceToStart.Size = New System.Drawing.Size(114, 15)
         Me.chkSpotifyForceToStart.TabIndex = 77
         Me.chkSpotifyForceToStart.Text = "FORCE_TO_START"
         Me.chkSpotifyForceToStart.UseSelectable = True
@@ -1729,10 +1790,10 @@ Partial Class NHLGamesMetro
         'chkSpotifyPlayNextSong
         '
         Me.chkSpotifyPlayNextSong.AutoSize = True
-        Me.chkSpotifyPlayNextSong.Location = New System.Drawing.Point(141, 6)
+        Me.chkSpotifyPlayNextSong.Location = New System.Drawing.Point(138, 6)
         Me.chkSpotifyPlayNextSong.Margin = New System.Windows.Forms.Padding(6)
         Me.chkSpotifyPlayNextSong.Name = "chkSpotifyPlayNextSong"
-        Me.chkSpotifyPlayNextSong.Size = New System.Drawing.Size(121, 15)
+        Me.chkSpotifyPlayNextSong.Size = New System.Drawing.Size(120, 15)
         Me.chkSpotifyPlayNextSong.TabIndex = 78
         Me.chkSpotifyPlayNextSong.Text = "PLAY_NEXT_SONG"
         Me.chkSpotifyPlayNextSong.UseSelectable = True
@@ -1740,7 +1801,7 @@ Partial Class NHLGamesMetro
         'chkSpotifyAnyMediaPlayer
         '
         Me.chkSpotifyAnyMediaPlayer.AutoSize = True
-        Me.chkSpotifyAnyMediaPlayer.Location = New System.Drawing.Point(274, 6)
+        Me.chkSpotifyAnyMediaPlayer.Location = New System.Drawing.Point(270, 6)
         Me.chkSpotifyAnyMediaPlayer.Margin = New System.Windows.Forms.Padding(6)
         Me.chkSpotifyAnyMediaPlayer.Name = "chkSpotifyAnyMediaPlayer"
         Me.chkSpotifyAnyMediaPlayer.Size = New System.Drawing.Size(133, 15)
@@ -1901,6 +1962,16 @@ Partial Class NHLGamesMetro
         Me.lblDarkMode.Text = "DARK"
         Me.lblDarkMode.TextAlign = System.Drawing.ContentAlignment.MiddleRight
         '
+        'flpAdActionDelay
+        '
+        Me.flpAdActionDelay.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.flpAdActionDelay.Enabled = False
+        Me.flpAdActionDelay.Location = New System.Drawing.Point(174, 930)
+        Me.flpAdActionDelay.Margin = New System.Windows.Forms.Padding(0)
+        Me.flpAdActionDelay.Name = "flpAdActionDelay"
+        Me.flpAdActionDelay.Size = New System.Drawing.Size(771, 30)
+        Me.flpAdActionDelay.TabIndex = 526
+        '
         'tabConsole
         '
         Me.tabConsole.Controls.Add(Me.btnCopyConsole)
@@ -1995,10 +2066,10 @@ Partial Class NHLGamesMetro
         Me.lblStatus.FontSize = MetroFramework.MetroLabelSize.Small
         Me.lblStatus.FontWeight = MetroFramework.MetroLabelWeight.Regular
         Me.lblStatus.ForeColor = System.Drawing.Color.Black
-        Me.lblStatus.Location = New System.Drawing.Point(934, 0)
+        Me.lblStatus.Location = New System.Drawing.Point(936, 0)
         Me.lblStatus.Margin = New System.Windows.Forms.Padding(20, 0, 3, 0)
         Me.lblStatus.Name = "lblStatus"
-        Me.lblStatus.Size = New System.Drawing.Size(47, 38)
+        Me.lblStatus.Size = New System.Drawing.Size(45, 38)
         Me.lblStatus.TabIndex = 26
         Me.lblStatus.Text = "STATUS"
         Me.lblStatus.TextAlign = System.Drawing.ContentAlignment.MiddleRight
@@ -2051,7 +2122,7 @@ Partial Class NHLGamesMetro
         Me.TableLayoutPanel1.Name = "TableLayoutPanel1"
         Me.TableLayoutPanel1.RowCount = 1
         Me.TableLayoutPanel1.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
-        Me.TableLayoutPanel1.Size = New System.Drawing.Size(742, 38)
+        Me.TableLayoutPanel1.Size = New System.Drawing.Size(744, 38)
         Me.TableLayoutPanel1.TabIndex = 63
         '
         'lnkRelease
@@ -2081,7 +2152,7 @@ Partial Class NHLGamesMetro
         Me.lblTip.Location = New System.Drawing.Point(62, 0)
         Me.lblTip.Margin = New System.Windows.Forms.Padding(0)
         Me.lblTip.Name = "lblTip"
-        Me.lblTip.Size = New System.Drawing.Size(680, 38)
+        Me.lblTip.Size = New System.Drawing.Size(682, 38)
         Me.lblTip.TabIndex = 62
         Me.lblTip.Text = "TIP"
         Me.lblTip.TextAlign = System.Drawing.ContentAlignment.MiddleLeft
@@ -2351,4 +2422,8 @@ End Sub
     Friend WithEvents lnkRelease As MetroLink
     Friend WithEvents lblTip As MetroLabel
     Friend WithEvents TableLayoutPanel1 As TableLayoutPanel
+    Friend WithEvents txtAdActionDelay As MetroTextBox
+    Friend WithEvents lblAdActionDelayMs As MetroLabel
+    Friend WithEvents flpAdActionDelay As FlowLayoutPanel
+    Friend WithEvents lblAdActionDelay As MetroLabel
 End Class

--- a/NHLGames/NHLGamesMetro.resx
+++ b/NHLGames/NHLGamesMetro.resx
@@ -136,7 +136,7 @@
     <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>25</value>
+    <value>51</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/NHLGames/NHLGamesMetro.resx
+++ b/NHLGames/NHLGamesMetro.resx
@@ -132,9 +132,6 @@
   <metadata name="bw.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>51</value>
   </metadata>

--- a/NHLGames/NHLGamesMetro.vb
+++ b/NHLGames/NHLGamesMetro.vb
@@ -569,7 +569,7 @@ Public Class NHLGamesMetro
             spotify.ForceToOpen = chkSpotifyForceToStart.Checked
             spotify.PlayNextSong = chkSpotifyPlayNextSong.Checked
             spotify.AnyMediaPlayer = chkSpotifyAnyMediaPlayer.Checked
-            spotify.ActionDelay = txtAdActionDelay.Text
+            spotify.MediaControlDelay = txtMediaControlDelay.Text
             _adDetectionEngine.AddModule(spotify)
         ElseIf _adDetectionEngine.IsInAdModulesList(spotify.Title) Then
             _adDetectionEngine.RemoveModule(spotify.Title)
@@ -580,12 +580,12 @@ Public Class NHLGamesMetro
                                        If(tgSpotify.Checked, English.msgOn, English.msgOff))
     End Sub
 
-    Private Sub txtAdActionDelay_KeyPress(sender As Object, e As KeyPressEventArgs) Handles txtAdActionDelay.KeyPress
+    Private Sub txtAdActionDelay_KeyPress(sender As Object, e As KeyPressEventArgs) Handles txtMediaControlDelay.KeyPress
         e.Handled = Not Char.IsDigit(e.KeyChar) And Not Char.IsControl(e.KeyChar)
     End Sub
 
-    Private Sub txtAdActionDelay_TextChanged(sender As Object, e As EventArgs) Handles txtAdActionDelay.TextChanged
-        If Not String.IsNullOrEmpty(txtAdActionDelay.Text) Then
+    Private Sub txtAdActionDelay_TextChanged(sender As Object, e As EventArgs) Handles txtMediaControlDelay.TextChanged
+        If Not String.IsNullOrEmpty(txtMediaControlDelay.Text) Then
             AdDetection.Renew()
         End If
     End Sub

--- a/NHLGames/NHLGamesMetro.vb
+++ b/NHLGames/NHLGamesMetro.vb
@@ -580,11 +580,11 @@ Public Class NHLGamesMetro
                                        If(tgSpotify.Checked, English.msgOn, English.msgOff))
     End Sub
 
-    Private Sub txtAdActionDelay_KeyPress(sender As Object, e As KeyPressEventArgs) Handles txtMediaControlDelay.KeyPress
+    Private Sub txtMediaControlDelay_KeyPress(sender As Object, e As KeyPressEventArgs) Handles txtMediaControlDelay.KeyPress
         e.Handled = Not Char.IsDigit(e.KeyChar) And Not Char.IsControl(e.KeyChar)
     End Sub
 
-    Private Sub txtAdActionDelay_TextChanged(sender As Object, e As EventArgs) Handles txtMediaControlDelay.TextChanged
+    Private Sub txtMediaControlDelay_TextChanged(sender As Object, e As EventArgs) Handles txtMediaControlDelay.TextChanged
         If Not String.IsNullOrEmpty(txtMediaControlDelay.Text) Then
             AdDetection.Renew()
         End If

--- a/NHLGames/NHLGamesMetro.vb
+++ b/NHLGames/NHLGamesMetro.vb
@@ -569,6 +569,7 @@ Public Class NHLGamesMetro
             spotify.ForceToOpen = chkSpotifyForceToStart.Checked
             spotify.PlayNextSong = chkSpotifyPlayNextSong.Checked
             spotify.AnyMediaPlayer = chkSpotifyAnyMediaPlayer.Checked
+            spotify.ActionDelay = txtAdActionDelay.Text
             _adDetectionEngine.AddModule(spotify)
         ElseIf _adDetectionEngine.IsInAdModulesList(spotify.Title) Then
             _adDetectionEngine.RemoveModule(spotify.Title)
@@ -577,6 +578,16 @@ Public Class NHLGamesMetro
         AdDetection.Renew()
         _writeToConsoleSettingsChanged(String.Format(English.msgThisEnable, lblSpotify.Text),
                                        If(tgSpotify.Checked, English.msgOn, English.msgOff))
+    End Sub
+
+    Private Sub txtAdActionDelay_KeyPress(sender As Object, e As KeyPressEventArgs) Handles txtAdActionDelay.KeyPress
+        e.Handled = Not Char.IsDigit(e.KeyChar) And Not Char.IsControl(e.KeyChar)
+    End Sub
+
+    Private Sub txtAdActionDelay_TextChanged(sender As Object, e As EventArgs) Handles txtAdActionDelay.TextChanged
+        If Not String.IsNullOrEmpty(txtAdActionDelay.Text) Then
+            AdDetection.Renew()
+        End If
     End Sub
 
     Private Sub cbStreamQuality_SelectedIndexChanged(sender As Object, e As EventArgs) _
@@ -751,7 +762,6 @@ Public Class NHLGamesMetro
         End Try
     End Sub
 
-
     Private Sub tbProxyPort_ValueChanged(sender As Object, e As EventArgs) Handles tbProxyPort.ValueChanged
         Dim value = tbProxyPort.Value * 10
         lblProxyPortNumber.Text = value.ToString()
@@ -763,5 +773,4 @@ Public Class NHLGamesMetro
         ApplicationSettings.SetValue(SettingsEnum.ProxyPort, value)
         _writeToConsoleSettingsChanged(lblProxyPort.Text, value.ToString())
     End Sub
-
 End Class

--- a/NHLGames/Objects/Modules/Spotify.vb
+++ b/NHLGames/Objects/Modules/Spotify.vb
@@ -31,7 +31,7 @@ Namespace Objects.Modules
         Public Property ForceToOpen As Boolean
         Public Property PlayNextSong As Boolean
         Public Property AnyMediaPlayer As Boolean
-        Public Property ActionDelay As Integer
+        Public Property MediaControlDelay As Integer
 
         Public ReadOnly Property Title As AdModulesEnum = AdModulesEnum.Spotify Implements IAdModule.Title
 
@@ -55,14 +55,14 @@ Namespace Objects.Modules
             Return File.Exists(_spotifyPath)
         End Function
 
-        Private Function IsSpotifyPlaying As Boolean
+        Private Function IsSpotifyPlaying() As Boolean
             Dim spotifyAudioSession = GetAudioSession(_spotifyId)
             Return GetCurrentVolume(spotifyAudioSession) > 0.0
         End Function
 
         Private Sub NextSong()
             If AnyMediaPlayer Then
-                Thread.Sleep(ActionDelay)
+                Thread.Sleep(MediaControlDelay)
                 NativeMethods.PressKey(KeyVkNextSong)
             Else
                 SendActionKey(KeyNextSong)
@@ -73,7 +73,7 @@ Namespace Objects.Modules
             Dim curr? = NativeMethods.GetForegroundWindowFromHandle()
             Dim spotifyHandle? = Process.GetProcessById(_spotifyId).MainWindowHandle
             NativeMethods.SetForegroundWindowFromHandle(spotifyHandle)
-            Thread.Sleep(ActionDelay)
+            Thread.Sleep(MediaControlDelay)
             SendKeys.SendWait(KeyTab) 'to unfocus any current field on spotify
             SendKeys.SendWait(Key)
             NativeMethods.SetBackgroundWindowFromHandle(spotifyHandle)
@@ -82,7 +82,7 @@ Namespace Objects.Modules
 
         Private Sub Play()
             If AnyMediaPlayer Then
-                Thread.Sleep(ActionDelay)
+                Thread.Sleep(MediaControlDelay)
                 NativeMethods.PressKey(KeyVkPlayPause)
             Else
                 If IsSpotifyPlaying() Then Return
@@ -92,7 +92,7 @@ Namespace Objects.Modules
 
         Private Sub Pause()
             If AnyMediaPlayer Then
-                Thread.Sleep(ActionDelay)
+                Thread.Sleep(MediaControlDelay)
                 NativeMethods.PressKey(KeyVkPlayPause)
             Else
                 If Not IsSpotifyPlaying() Then Return

--- a/NHLGames/Objects/Modules/Spotify.vb
+++ b/NHLGames/Objects/Modules/Spotify.vb
@@ -62,7 +62,7 @@ Namespace Objects.Modules
 
         Private Sub NextSong()
             If AnyMediaPlayer Then
-                Thread.Sleep(100)
+                Thread.Sleep(ActionDelay)
                 NativeMethods.PressKey(KeyVkNextSong)
             Else
                 SendActionKey(KeyNextSong)
@@ -73,7 +73,7 @@ Namespace Objects.Modules
             Dim curr? = NativeMethods.GetForegroundWindowFromHandle()
             Dim spotifyHandle? = Process.GetProcessById(_spotifyId).MainWindowHandle
             NativeMethods.SetForegroundWindowFromHandle(spotifyHandle)
-            Thread.Sleep(100)
+            Thread.Sleep(ActionDelay)
             SendKeys.SendWait(KeyTab) 'to unfocus any current field on spotify
             SendKeys.SendWait(Key)
             NativeMethods.SetBackgroundWindowFromHandle(spotifyHandle)

--- a/NHLGames/Objects/Modules/Spotify.vb
+++ b/NHLGames/Objects/Modules/Spotify.vb
@@ -31,6 +31,7 @@ Namespace Objects.Modules
         Public Property ForceToOpen As Boolean
         Public Property PlayNextSong As Boolean
         Public Property AnyMediaPlayer As Boolean
+        Public Property ActionDelay As Integer
 
         Public ReadOnly Property Title As AdModulesEnum = AdModulesEnum.Spotify Implements IAdModule.Title
 
@@ -81,7 +82,7 @@ Namespace Objects.Modules
 
         Private Sub Play()
             If AnyMediaPlayer Then
-                Thread.Sleep(100)
+                Thread.Sleep(ActionDelay)
                 NativeMethods.PressKey(KeyVkPlayPause)
             Else
                 If IsSpotifyPlaying() Then Return
@@ -91,7 +92,7 @@ Namespace Objects.Modules
 
         Private Sub Pause()
             If AnyMediaPlayer Then
-                Thread.Sleep(100)
+                Thread.Sleep(ActionDelay)
                 NativeMethods.PressKey(KeyVkPlayPause)
             Else
                 If Not IsSpotifyPlaying() Then Return

--- a/NHLGames/Utilities/AdDetection.vb
+++ b/NHLGames/Utilities/AdDetection.vb
@@ -195,8 +195,8 @@ Namespace Utilities
                     .EnabledSpotifyAndAnyMediaPlayer = form.chkSpotifyAnyMediaPlayer.Checked
                 }
 
-                If Not String.IsNullOrEmpty(form.txtAdActionDelay.Text) Then
-                    _settings.AdActionDelay = form.txtAdActionDelay.Text
+                If Not String.IsNullOrEmpty(form.txtMediaControlDelay.Text) Then
+                    _settings.MediaControlDelay = form.txtMediaControlDelay.Text
                 End If
 
                 _settings.EnabledObsGameSceneHotKey.Key = form.txtGameKey.Text

--- a/NHLGames/Utilities/AdDetection.vb
+++ b/NHLGames/Utilities/AdDetection.vb
@@ -195,6 +195,10 @@ Namespace Utilities
                     .EnabledSpotifyAndAnyMediaPlayer = form.chkSpotifyAnyMediaPlayer.Checked
                 }
 
+                If Not String.IsNullOrEmpty(form.txtAdActionDelay.Text) Then
+                    _settings.AdActionDelay = form.txtAdActionDelay.Text
+                End If
+
                 _settings.EnabledObsGameSceneHotKey.Key = form.txtGameKey.Text
                 _settings.EnabledObsGameSceneHotKey.Ctrl = form.chkGameCtrl.Checked
                 _settings.EnabledObsGameSceneHotKey.Alt = form.chkGameAlt.Checked

--- a/NHLGames/Utilities/AdDetectionConfigs.vb
+++ b/NHLGames/Utilities/AdDetectionConfigs.vb
@@ -10,6 +10,6 @@ Namespace Utilities
         Public Property EnabledSpotifyForceToOpen As Boolean = False
         Public Property EnabledSpotifyPlayNextSong As Boolean = False
         Public Property EnabledSpotifyAndAnyMediaPlayer As Boolean = False
-        Public Property AdActionDelay As Integer = 100
+        Public Property MediaControlDelay As Integer = 100
     End Class
 End Namespace

--- a/NHLGames/Utilities/AdDetectionConfigs.vb
+++ b/NHLGames/Utilities/AdDetectionConfigs.vb
@@ -10,5 +10,6 @@ Namespace Utilities
         Public Property EnabledSpotifyForceToOpen As Boolean = False
         Public Property EnabledSpotifyPlayNextSong As Boolean = False
         Public Property EnabledSpotifyAndAnyMediaPlayer As Boolean = False
+        Public Property AdActionDelay As Integer = 100
     End Class
 End Namespace

--- a/NHLGames/Utilities/InitializeForm.vb
+++ b/NHLGames/Utilities/InitializeForm.vb
@@ -92,13 +92,13 @@ Namespace Utilities
             Form.tt.SetToolTip(Form.btnOutput, NHLGamesMetro.RmText.GetString("tipBrowse"))
             Form.tt.SetToolTip(Form.tbProxyPort, NHLGamesMetro.RmText.GetString("tipTrackBarMove"))
             Form.tt.SetToolTip(Form.tbLiveRewind, NHLGamesMetro.RmText.GetString("tipTrackBarMove"))
-            Form.tt.SetToolTip(Form.lblAdActionDelay, NHLGamesMetro.RmText.GetString("tipAdActionDelay"))
+            Form.tt.SetToolTip(Form.lblMediaControlDelay, NHLGamesMetro.RmText.GetString("tipMediaControlDelay"))
 
             Form.lblModules.Text = NHLGamesMetro.RmText.GetString("lblModules")
             Form.lblModulesDesc.Text = NHLGamesMetro.RmText.GetString("lblModulesDesc")
             Form.lblSpotify.Text = NHLGamesMetro.RmText.GetString("lblSpotify")
             Form.lblSpotifyDesc.Text = NHLGamesMetro.RmText.GetString("lblSpotifyDesc")
-            Form.lblAdActionDelay.Text = NHLGamesMetro.RmText.GetString("lblAdActionDelay")
+            Form.lblMediaControlDelay.Text = NHLGamesMetro.RmText.GetString("lblMediaControlDelay")
             Form.lblOBS.Text = NHLGamesMetro.RmText.GetString("lblObs")
             Form.lblOBSDesc.Text = NHLGamesMetro.RmText.GetString("lblObsDesc")
             Form.lblObsAdEndingHotkey.Text = NHLGamesMetro.RmText.GetString("lblObsAdEndingHotkey")
@@ -333,7 +333,7 @@ Namespace Utilities
                 Form.chkSpotifyForceToStart.Checked = configs.EnabledSpotifyForceToOpen
                 Form.chkSpotifyPlayNextSong.Checked = configs.EnabledSpotifyPlayNextSong
                 Form.chkSpotifyAnyMediaPlayer.Checked = configs.EnabledSpotifyAndAnyMediaPlayer
-                Form.txtAdActionDelay.Text = configs.AdActionDelay
+                Form.txtMediaControlDelay.Text = configs.MediaControlDelay
 
                 Form.txtAdKey.Text = configs.EnabledObsAdSceneHotKey.Key
                 Form.chkAdCtrl.Checked = configs.EnabledObsAdSceneHotKey.Ctrl
@@ -449,10 +449,10 @@ Namespace Utilities
                 Form.lblSpotify.Theme = MetroThemeStyle.Dark
                 Form.tgSpotify.Theme = MetroThemeStyle.Dark
                 Form.lblSpotifyDesc.Theme = MetroThemeStyle.Dark
-                Form.lblAdActionDelay.Theme = MetroThemeStyle.Dark
-                Form.txtAdActionDelay.BackColor = Color.FromArgb(80, 80, 80)
-                Form.txtAdActionDelay.ForeColor = Color.LightGray
-                Form.lblAdActionDelayMs.Theme = MetroThemeStyle.Dark
+                Form.lblMediaControlDelay.Theme = MetroThemeStyle.Dark
+                Form.txtMediaControlDelay.BackColor = Color.FromArgb(80, 80, 80)
+                Form.txtMediaControlDelay.ForeColor = Color.LightGray
+                Form.lblMediaControlDelayMs.Theme = MetroThemeStyle.Dark
                 Form.chkSpotifyForceToStart.Theme = MetroThemeStyle.Dark
                 Form.chkSpotifyPlayNextSong.Theme = MetroThemeStyle.Dark
                 Form.chkSpotifyAnyMediaPlayer.Theme = MetroThemeStyle.Dark

--- a/NHLGames/Utilities/InitializeForm.vb
+++ b/NHLGames/Utilities/InitializeForm.vb
@@ -92,11 +92,13 @@ Namespace Utilities
             Form.tt.SetToolTip(Form.btnOutput, NHLGamesMetro.RmText.GetString("tipBrowse"))
             Form.tt.SetToolTip(Form.tbProxyPort, NHLGamesMetro.RmText.GetString("tipTrackBarMove"))
             Form.tt.SetToolTip(Form.tbLiveRewind, NHLGamesMetro.RmText.GetString("tipTrackBarMove"))
+            Form.tt.SetToolTip(Form.lblAdActionDelay, NHLGamesMetro.RmText.GetString("tipAdActionDelay"))
 
             Form.lblModules.Text = NHLGamesMetro.RmText.GetString("lblModules")
             Form.lblModulesDesc.Text = NHLGamesMetro.RmText.GetString("lblModulesDesc")
             Form.lblSpotify.Text = NHLGamesMetro.RmText.GetString("lblSpotify")
             Form.lblSpotifyDesc.Text = NHLGamesMetro.RmText.GetString("lblSpotifyDesc")
+            Form.lblAdActionDelay.Text = NHLGamesMetro.RmText.GetString("lblAdActionDelay")
             Form.lblOBS.Text = NHLGamesMetro.RmText.GetString("lblObs")
             Form.lblOBSDesc.Text = NHLGamesMetro.RmText.GetString("lblObsDesc")
             Form.lblObsAdEndingHotkey.Text = NHLGamesMetro.RmText.GetString("lblObsAdEndingHotkey")
@@ -331,6 +333,7 @@ Namespace Utilities
                 Form.chkSpotifyForceToStart.Checked = configs.EnabledSpotifyForceToOpen
                 Form.chkSpotifyPlayNextSong.Checked = configs.EnabledSpotifyPlayNextSong
                 Form.chkSpotifyAnyMediaPlayer.Checked = configs.EnabledSpotifyAndAnyMediaPlayer
+                Form.txtAdActionDelay.Text = configs.AdActionDelay
 
                 Form.txtAdKey.Text = configs.EnabledObsAdSceneHotKey.Key
                 Form.chkAdCtrl.Checked = configs.EnabledObsAdSceneHotKey.Ctrl
@@ -446,6 +449,11 @@ Namespace Utilities
                 Form.lblSpotify.Theme = MetroThemeStyle.Dark
                 Form.tgSpotify.Theme = MetroThemeStyle.Dark
                 Form.lblSpotifyDesc.Theme = MetroThemeStyle.Dark
+                Form.txtAdActionDelay.BackColor = Color.FromArgb(80, 80, 80)
+                Form.txtAdActionDelay.ForeColor = Color.LightGray
+                Form.lblAdActionDelayMs.Theme = MetroThemeStyle.Dark
+                Form.lblAdActionDelay.Theme = MetroThemeStyle.Dark
+                Form.lblAdActionDelayMs.Theme = MetroThemeStyle.Dark
                 Form.chkSpotifyForceToStart.Theme = MetroThemeStyle.Dark
                 Form.chkSpotifyPlayNextSong.Theme = MetroThemeStyle.Dark
                 Form.chkSpotifyAnyMediaPlayer.Theme = MetroThemeStyle.Dark

--- a/NHLGames/Utilities/InitializeForm.vb
+++ b/NHLGames/Utilities/InitializeForm.vb
@@ -449,10 +449,9 @@ Namespace Utilities
                 Form.lblSpotify.Theme = MetroThemeStyle.Dark
                 Form.tgSpotify.Theme = MetroThemeStyle.Dark
                 Form.lblSpotifyDesc.Theme = MetroThemeStyle.Dark
+                Form.lblAdActionDelay.Theme = MetroThemeStyle.Dark
                 Form.txtAdActionDelay.BackColor = Color.FromArgb(80, 80, 80)
                 Form.txtAdActionDelay.ForeColor = Color.LightGray
-                Form.lblAdActionDelayMs.Theme = MetroThemeStyle.Dark
-                Form.lblAdActionDelay.Theme = MetroThemeStyle.Dark
                 Form.lblAdActionDelayMs.Theme = MetroThemeStyle.Dark
                 Form.chkSpotifyForceToStart.Theme = MetroThemeStyle.Dark
                 Form.chkSpotifyPlayNextSong.Theme = MetroThemeStyle.Dark


### PR DESCRIPTION
Enables customization of the delay before playing, pausing or skipping to next track in the ad detection feature.

Can fix an issue where Pause() is called twice in a row if the first one completes too early.

Replaces the hard coded 100ms delay with a default 100ms delay.